### PR TITLE
RunEpidemic error

### DIFF
--- a/RunEpidemicPlot.ipynb
+++ b/RunEpidemicPlot.ipynb
@@ -2,14 +2,14 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import copy as copy\n",
-    "from policy_MC import RunEpidemic as simulation"
+    "from simulation import RunEpidemic as simulation"
    ]
   },
   {


### PR DESCRIPTION
RunEpidemicPlot was trying to call the old simulation name (policy_MC) instead of the new name (simulation), so it had an error and wouldn't run.