### PR TITLE
population.py docstrings

### DIFF
--- a/cv19/population.py
+++ b/cv19/population.py
@@ -22,8 +22,8 @@ class Population:
 
         Parameters
         ----------
-        sim_obj : :obj:`simulation class`
-            The encompassing simulation object hosting the simulation.
+        sim_obj : :obj:`population class`
+            The encompassing simulation object hosting the population class.
         '''
 
         # Set attributes from sim_obj file
@@ -325,7 +325,7 @@ class Population:
 
         Returns
         -------
-        self.dead[self.deadd != NULL_ID]: :obj:`np.array` of :obj:`int`
+        self.dead[self.dead != NULL_ID]: :obj:`np.array` of :obj:`int`
         '''
         return self.dead[self.dead != NULL_ID]
 


### PR DESCRIPTION
Adding the remaining docstrings to the population.py class. We can wait to merge this until after Mark's pull request to add more documentation is merged.

In this pull:
- Added docstrings to population.py
- Made all the docstrings consistent in the person class (line spaces, periods, etc...)

Let me know if there is anything that should be changed!

Thanks,
Ashley