### PR TITLE
Remove docstring messages from Pylint disabled list

### DIFF
--- a/test/linters/pylint.py
+++ b/test/linters/pylint.py
@@ -15,8 +15,6 @@ def run_pylint():
     messages_enable = ['all']
     messages_disable = ['R',
                         'line-too-long',
-                        'missing-function-docstring',
-                        'missing-class-docstring',
                         'missing-module-docstring',
                         'invalid-name',
                         'attribute-defined-outside-init',


### PR DESCRIPTION
Pylint will now check for docstrings for new classes and functions/methods. @NoahRowe you can merge this whenever.