### PR TITLE
Change lockdown to have B closed instead of A

### DIFF
--- a/cv19/simulation.py
+++ b/cv19/simulation.py
@@ -368,11 +368,11 @@ class simulation():
                 self.pop.population.append(visitor)
 
             ############### INTERACTION SITES STUFF ###############
-            will_visit_A = self.inter_sites.will_visit_site(self.inter_sites.get_grade_A_sites(), self.will_go_prob["A"])
-            self.inter_sites.site_interaction(will_visit_A, day, personal=True)
+            will_visit_B = self.inter_sites.will_visit_site(self.inter_sites.get_grade_B_sites(), self.will_go_prob["B"])
+            self.inter_sites.site_interaction(will_visit_B, day, personal=False)
             if not lockdown:
-                will_visit_B = self.inter_sites.will_visit_site(self.inter_sites.get_grade_B_sites(), self.will_go_prob["B"])
-                self.inter_sites.site_interaction(will_visit_B, day, personal=False)
+                will_visit_A = self.inter_sites.will_visit_site(self.inter_sites.get_grade_A_sites(), self.will_go_prob["A"])
+                self.inter_sites.site_interaction(will_visit_A, day, personal=True)
                 will_visit_C = self.inter_sites.will_visit_site(self.inter_sites.get_grade_C_sites(), self.will_go_prob["C"])
                 self.inter_sites.site_interaction(will_visit_C, day, personal=False)
 


### PR DESCRIPTION
During the last meeting we had the discussion that it makes more sense for B (grocery stores) to be open during a lock down, instead of A (restaurants). C (work) remained the same, ie closed, during the lock down.